### PR TITLE
Fix dead area on the left-hand side of the map page.

### DIFF
--- a/hexland-web/src/Map.css
+++ b/hexland-web/src/Map.css
@@ -22,12 +22,14 @@
   height: calc(100vh - 8rem);
   min-width: 3rem;
   z-index: 4;
+  pointer-events: none;
 }
 
 .Map-control {
   background-color: transparent;
   margin-left: 1rem;
   margin-top: 1rem;
+  pointer-events: auto;
 }
 
 .Map-content {


### PR DESCRIPTION
Dead area is to the left of and around the map controls on the left hand side
of the map page. Fix by using CSS to disable pointer events on the invisible
wrapper of the map controls, and explicitly enabling pointer events on the
map control buttons.

Closes #133 