### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/hexland-web/src/components/AnalyticsContextProvider.tsx
+++ b/hexland-web/src/components/AnalyticsContextProvider.tsx
@@ -53,7 +53,7 @@ export function AnalyticsContextProvider({ children, getItem, setItem }: IContex
     enabled: enabled,
     setEnabled: setEnabled,
     logError: (message: string, e: any, fatal?: boolean | undefined) => {
-      console.error(message, e);
+      console.error("Analytics error:", message, e);
       if (enabled) {
         console.info("logging to analytics with error: " + getExMessage(e));
         analytics?.logEvent("exception", {


### PR DESCRIPTION
Potential fix for [https://github.com/KaiEkkrin/hexland/security/code-scanning/2](https://github.com/KaiEkkrin/hexland/security/code-scanning/2)

General fix approach: ensure that untrusted data is never used as the format string argument. Instead, pass a constant format string (or no format string at all) and supply untrusted data as subsequent arguments or otherwise sanitize/escape it before concatenation.

Best fix here without changing functionality: adjust the `console.error` call inside `AnalyticsContextProvider` so that `message` is not used as the format string. Two straightforward options:
- Use a constant prefix and pass `message` and `e` as separate arguments: `console.error("Analytics error:", message, e);`, or
- Use an explicit `%s` format string: `console.error("%s", message, e);`.

The first option is clearer and keeps all information while eliminating the format-string dependency on user input. It is also generic enough to cover all alert variants, since every `logError` call flows through this one implementation.

Concrete change:
- File: `hexland-web/src/components/AnalyticsContextProvider.tsx`
- In the `analyticsContext` definition, inside `logError`, replace line 56:
  - From: `console.error(message, e);`
  - To: `console.error("Analytics error:", message, e);`

No other files (`Invite.tsx`, `Adventure.tsx`) require modification, because the root cause is the sink usage in `AnalyticsContextProvider`. No new imports or helper methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
