### PR TITLE
Disallow all by default in robots.txt

### DIFF
--- a/hexland-web/public/robots.txt
+++ b/hexland-web/public/robots.txt
@@ -1,3 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
We don't want search engines indexing the test site!