### PR TITLE
Bump react-router-dom to 6.30.4 (CVE-2026-40181)

### DIFF
--- a/was-web/package.json
+++ b/was-web/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
     "react-router-bootstrap": "^0.26.3",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^6.30.4",
     "react-use-measure": "^2.1.1",
     "rxjs": "^7.8.0",
     "three": "^0.183.0",

--- a/was-web/yarn.lock
+++ b/was-web/yarn.lock
@@ -1529,10 +1529,10 @@
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.34.0.tgz#f9688443fdf8e29f7a06b499598a930be96a2f65"
   integrity sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==
 
-"@remix-run/router@1.23.2":
-  version "1.23.2"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
-  integrity sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==
+"@remix-run/router@1.23.3":
+  version "1.23.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
+  integrity sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==
 
 "@restart/hooks@^0.4.9":
   version "0.4.16"
@@ -5112,20 +5112,20 @@ react-router-bootstrap@^0.26.3:
   dependencies:
     prop-types "^15.7.2"
 
-react-router-dom@^6.30.3:
-  version "6.30.3"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.3.tgz#42ae6dc4c7158bfb0b935f162b9621b29dddf740"
-  integrity sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==
+react-router-dom@^6.30.4:
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.4.tgz#f7167bf3da6c7d9132130ea985dd06def25e84d5"
+  integrity sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==
   dependencies:
-    "@remix-run/router" "1.23.2"
-    react-router "6.30.3"
+    "@remix-run/router" "1.23.3"
+    react-router "6.30.4"
 
-react-router@6.30.3:
-  version "6.30.3"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
-  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
+react-router@6.30.4:
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.4.tgz#638f35176527bd243d96d81d35d33b757bad46c2"
+  integrity sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==
   dependencies:
-    "@remix-run/router" "1.23.2"
+    "@remix-run/router" "1.23.3"
 
 react-stately@3.46.0:
   version "3.46.0"


### PR DESCRIPTION
## Summary

- Closes the Dependabot alert for [CVE-2026-40181](https://github.com/advisories/GHSA-2w69-qvjg-hvjx): paths beginning `//` passed to `react-router`'s `redirect()` get reinterpreted as protocol-relative URLs. Affected: `react-router` 6.7.0–6.30.3 and 7.0.0–7.14.0; patched in 6.30.4 / 7.14.1.
- We are not exposed in practice — the app uses declarative `<BrowserRouter>` mode (the advisory explicitly excludes this), never calls `redirect()`, and `loginRedirect.ts` already restricts the `from` query parameter to internal paths. Bumping anyway to clear the alert.
- `react-router-bootstrap@0.26.3`'s peer dep is `react-router-dom: >=6.0.0`, so the patch release does not conflict. The v6 → v7 migration remains deferred per `docs/Medium_Term_Updates.md`.

## Test plan

- [x] `yarn lint` — clean
- [x] `yarn build` — succeeds (no new warnings)
- [x] `yarn test:unit` — 269/269 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)