### PR TITLE
Fix image e2e tests by promoting test user to Higher tier

### DIFF
--- a/was-web/e2e/image.test.ts
+++ b/was-web/e2e/image.test.ts
@@ -1,19 +1,27 @@
 import { test, expect } from '@playwright/test';
 
 import * as Util from './util';
+import { setUserLevel } from './dbAdmin';
 import { TINY_PNG } from './testImage';
 
 test.describe('Image management tests', () => {
-  test.beforeEach(async ({ page }) => {
+  // All tests in this describe block exercise image-upload UI, which is gated
+  // behind the Higher tier (Basic caps images at 0 — see policy.ts). The
+  // beforeEach signs up a fresh user, then promotes them in the DB and reloads
+  // so the client picks up the new tier from /api/auth/me. This mirrors the
+  // pattern used by admin.test.ts.
+  test.beforeEach(async ({ page }, testInfo) => {
+    const deviceName = Util.getDeviceNameFromProject(testInfo.project.name);
     await page.goto('/');
     await expect(page.locator('.App-login-text').first()).toBeVisible();
+    const user = await Util.signUp(page, deviceName);
+    await setUserLevel(user.email, 'higher');
+    await page.reload();
+    await expect(page.locator('h5 >> text="Latest maps"')).toBeVisible();
   });
 
-  test('upload image and assign to adventure', async ({ page }, testInfo) => {
-    const deviceName = Util.getDeviceNameFromProject(testInfo.project.name);
-
-    // Sign up and create an adventure
-    await Util.signUp(page, deviceName);
+  test('upload image and assign to adventure', async ({ page }) => {
+    // Create an adventure
     await Util.createNewAdventure(page, 'Image test', 'Testing images');
     await expect(page).toHaveURL(/\/adventure\//);
 
@@ -36,11 +44,8 @@ test.describe('Image management tests', () => {
     await expect(page.locator('.card img.App-image-collection-image, .card img[alt="Image test"]')).toBeVisible({ timeout: 5000 });
   });
 
-  test('remove image from adventure', async ({ page }, testInfo) => {
-    const deviceName = Util.getDeviceNameFromProject(testInfo.project.name);
-
-    // Sign up and create an adventure
-    await Util.signUp(page, deviceName);
+  test('remove image from adventure', async ({ page }) => {
+    // Create an adventure
     await Util.createNewAdventure(page, 'Remove image test', 'Will remove image');
     await expect(page).toHaveURL(/\/adventure\//);
 
@@ -70,11 +75,8 @@ test.describe('Image management tests', () => {
     await expect(page.locator('.card img')).not.toBeVisible({ timeout: 5000 });
   });
 
-  test('delete an image', async ({ page }, testInfo) => {
-    const deviceName = Util.getDeviceNameFromProject(testInfo.project.name);
-
-    // Sign up and create an adventure
-    await Util.signUp(page, deviceName);
+  test('delete an image', async ({ page }) => {
+    // Create an adventure
     await Util.createNewAdventure(page, 'Delete image test', 'Will delete image');
     await expect(page).toHaveURL(/\/adventure\//);
 
@@ -106,8 +108,7 @@ test.describe('Image management tests', () => {
   test('assign image to map', async ({ page }, testInfo) => {
     const deviceName = Util.getDeviceNameFromProject(testInfo.project.name);
 
-    // Sign up and create an adventure
-    await Util.signUp(page, deviceName);
+    // Create an adventure
     await Util.createNewAdventure(page, 'Map image test', 'Testing map images');
     await expect(page).toHaveURL(/\/adventure\//);
 


### PR DESCRIPTION
## Summary

Fixes the four failing tests in `e2e/image.test.ts` (`upload image and assign to adventure`, `remove image from adventure`, `delete an image`, `assign image to map`) — all of which were timing out waiting for the adventure image button.

**Root cause**: image upload is gated behind the Higher tier (`policy.ts` sets Basic's image cap to 0, so the UI affordances are not rendered). `Util.signUp` creates a Basic-tier account, matching production signup, so the freshly-registered test user couldn't see the image button.

**Fix**: hoist signup into a `beforeEach` for the `Image management tests` describe block, then call `setUserLevel(user.email, 'higher')` from `e2e/dbAdmin.ts` followed by `page.reload()` so the client refetches `/api/auth/me` with the new tier. This is the same pattern `admin.test.ts` already uses when promoting a user mid-test.

`Util.signUp`'s default behaviour is intentionally unchanged: every other test that relies on a fresh Basic user (notably `admin.test.ts`'s tier-gate tests, which assert that image affordances are *absent* on Basic — but those use `createApiUser`, not `signUp`) is unaffected.

## Test plan

- [x] `yarn test:e2e --project chromium-desktop --grep "Image management"` — 4/4 pass
- [x] `yarn test:e2e` full matrix — **120 passed, 5 skipped, 0 failed** (previously 100 passed, 20 failed)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)