### PR TITLE
Fix test deploy failure: inode exhaustion from unpruned images

### DIFF
--- a/.github/workflows/deploy-server-production.yml
+++ b/.github/workflows/deploy-server-production.yml
@@ -84,4 +84,12 @@ jobs:
           sleep 5
           systemctl is-active --quiet wallandshadow-prod.service
           systemctl --no-pager --lines=20 status wallandshadow-prod.service
+          # Reap superseded images. Each deploy pulls a fresh per-SHA image
+          # whose node_modules layer holds tens of thousands of tiny files, so
+          # the root filesystem exhausts its *inodes* long before its bytes --
+          # 59 accumulated images broke test on 2026-07-25 with 9GB still free.
+          # Images referenced by a running container are never candidates, so
+          # this cannot remove the image started above or the live test one.
+          docker image prune -af --filter 'until=168h'
+          df -i /
           EOF

--- a/.github/workflows/deploy-server-test.yml
+++ b/.github/workflows/deploy-server-test.yml
@@ -101,4 +101,12 @@ jobs:
           sleep 5
           systemctl is-active --quiet wallandshadow-test.service
           systemctl --no-pager --lines=20 status wallandshadow-test.service
+          # Reap superseded images. Each deploy pulls a fresh per-SHA image
+          # whose node_modules layer holds tens of thousands of tiny files, so
+          # the root filesystem exhausts its *inodes* long before its bytes --
+          # 59 accumulated images broke test on 2026-07-25 with 9GB still free.
+          # Images referenced by a running container are never candidates, so
+          # this cannot remove the image started above or the live prod one.
+          docker image prune -af --filter 'until=168h'
+          df -i /
           EOF

--- a/was-web/Dockerfile
+++ b/was-web/Dockerfile
@@ -94,10 +94,12 @@ COPY server/docker-entrypoint.sh server/
 # Copy built SPA
 COPY --from=build-spa /app/build/ build/
 
-# Transfer ownership to the non-root node user (UID 1000) now that all files are in place.
-# Must come after all COPY commands because each COPY resets ownership to root.
-RUN chown -R node:node /app
-
+# Everything under /app stays root-owned and world-readable. The container runs
+# as the unprivileged node user (UID 1000) below and only ever reads /app —
+# runtime writes go to os.tmpdir() (spriteExtensions.ts), never to the app dir.
+# A recursive `chown -R node:node /app` here would rewrite every file into an
+# extra image layer, duplicating the whole of node_modules and doubling the
+# image's inode footprint on the deploy host.
 USER node
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Why

The test deploy for `#377` failed at `systemctl restart wallandshadow-test.service`, inside `ExecStartPre=/usr/bin/docker pull`:

```
failed to extract layer (... sha256:aa7feac53adc...) to overlayfs as "extract-667177228-b5c9 ...":
open /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3004/fs/app/
node_modules/three/src/renderers/common/ClippingContext.js: no space left on device
```

`ENOSPC` with 9 GB free — the root filesystem was out of **inodes**, not bytes:

```
/dev/sda1        38G   27G  9.1G  75% /
/dev/sda1      2427136 2395703 31433   99% /
```

Nothing in `ansible/` or the deploy workflows had ever removed an old application image, so 59 images had accumulated (1 active), each carrying a `node_modules` layer of tens of thousands of tiny files. Deploy `#374` at 09:27 still fit; `#375` at 09:33 was the one that ran the inode table out. `Restart=on-failure` then left the unit re-pulling every ~15 s for hours.

Neither the code nor the image was at fault — the published image pulls and verifies fine.

## What

**1. Prune superseded images after each deploy** (`deploy-server-test.yml`, `deploy-server-production.yml`)

`docker image prune -af --filter 'until=168h'` at the end of the restart step, plus a `df -i /` readout so inode headroom shows up in the deploy log. It runs after `systemctl is-active` succeeds, so a failed deploy prunes nothing, and images referenced by a running container are never candidates — the image just started and the other environment's live one are both safe.

Behavioural note: prod's image is months old and survives only because its container is running. If prod is stopped while a test deploy runs, prod's image is reaped and re-pulled by `ExecStartPre` on next start.

**2. Drop the recursive `chown` from the production image** (`was-web/Dockerfile`)

`RUN chown -R node:node /app` rewrote every file into a new layer, duplicating all of `node_modules` — the published image shows it as a 47.5 MB layer immediately after the 47.2 MB `yarn install --production` layer it copies. That doubled the inode cost of every image on the host.

The ownership transfer was never needed: nothing writes under `/app` at runtime (the only server-side filesystem writes, in `spriteExtensions.ts` via `storage.download`, target `os.tmpdir()`). Root-owned world-readable app files are also marginally better posture, since the unprivileged user can't rewrite its own code. `docker-entrypoint.sh` is committed `755`, so it stays executable.

## Verification

- Both workflow files parse as valid YAML; the added lines contain no `$` or backticks, so the unquoted heredoc passes them through intact.
- The Dockerfile change is **not** build-verified — the devcontainer has no container runtime. CI builds the image on this branch, and a test deploy is the canary before prod is dispatched.
- Recovery on the VPS (`docker image prune -af` after stopping the looping unit) is being applied separately; this PR stops the condition from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)