### PR TITLE
DO NOT MERGE: CI gate smoke test

### DIFF
--- a/docs/SMOKE-TEST-DELETE-ME.md
+++ b/docs/SMOKE-TEST-DELETE-ME.md
@@ -1,0 +1,5 @@
+# CI gate smoke test
+
+Throwaway file. This PR exists only to verify that the CI gate reports
+correctly when jobs are skipped, and blocks a merge when a job fails.
+It is never merged.

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -11,3 +11,6 @@ location     = "hel1"
 server_type  = "cx23"
 server_image = "ubuntu-24.04"
 volume_size  = 10
+
+# smoke test
+smoke_test_value=99


### PR DESCRIPTION
Verifies two things that could not be tested on #379 (whose diff contained ci.yml, so every job always ran):

1. **skip-as-pass** — a docs-only diff should skip every verification job while `CI gate` still reports green.
2. **the gate blocks a merge** — a second commit will deliberately break `tofu fmt`.

Close without merging.