### PR TITLE
docs: fold the deleted overlay design spec into ephemeral-state.md

### DIFF
--- a/docs/architecture/ephemeral-state.md
+++ b/docs/architecture/ephemeral-state.md
@@ -3,9 +3,16 @@
 How Wall & Shadow handles *transient, in-memory, never-persisted* collaboration
 signals — distinct from the durable map data that flows through the database.
 
-This note describes the subsystem as a whole. For what a particular function
-does, read the code; for the data-layer build that introduced live overlays,
-see `docs/superpowers/specs/2026-06-07-ephemeral-overlay-data-layer-design.md`.
+This note describes the subsystem as a whole — the boundaries, the invariants,
+and the reasoning behind them. For what a particular function does, read the
+code (see "Where the code lives" at the end).
+
+**Status.** The backplane is built and carries two tenants. Presence is wired
+end to end, UI included. Live overlays exist as a *data layer only*: the server
+registry, the wire contract, and the `ILiveData` client surface are implemented
+and tested, but the scribble and ruler UIs — rendering, input capture, per-author
+colour — are not on `main` yet. Nothing in the app currently calls
+`watchLiveOverlays`.
 
 ## What counts as ephemeral state
 
@@ -56,6 +63,30 @@ slow the interaction; routing map edits through the ephemeral path would lose
 data. New ephemeral features belong on the ephemeral path; anything that must
 survive a refresh belongs on the persistent path.
 
+## One socket, two backends
+
+The split above is a split of *backends*, not of transports. Both paths run over
+the single multiplexed WebSocket and through the same generic subscription
+machinery: a client subscribes to a **scope** (`mapChanges`, `presence`,
+`liveOverlay`, …) keyed by an entity id, gets a `snapshot` frame back, and then
+receives `roomUpdate` frames for as long as the subscription lives. Ephemeral
+scopes invented no new envelope; only the thing behind the scope differs — a
+database query for persistent scopes, an in-memory registry for ephemeral ones.
+
+Three consequences worth knowing:
+
+- **Authorization is uniform.** Subscribing to an ephemeral scope still runs the
+  same database-backed membership check as a persistent one. In-memory state is
+  not less protected state.
+- **Rooms are shared between the paths.** `liveOverlay` deliberately routes
+  through the *same* map-keyed room manager as `mapChanges` (presence uses the
+  adventure-keyed one), so a socket in a map room may hold either or both kinds
+  of subscription. Every broadcast therefore filters room members by scope
+  before sending — being in the room is not by itself permission to receive.
+- **Adding an ephemeral scope is a small, local change.** A scope name, a room
+  manager to route it to, a snapshot hook, and a registry module. No changes to
+  the socket, the subscription bookkeeping, or the room mechanics.
+
 ## Shape of the ephemeral backplane
 
 Both tenants follow the same server-side pattern (presence came first; live
@@ -72,32 +103,52 @@ overlay was built as the second tenant of it):
   and (for overlays) a removal is broadcast, so every client converges even if
   the originator vanished.
 
-The two tenants differ only in scope and payload:
+The two tenants differ in what they are keyed by, what they carry, and how much
+they say per broadcast:
 
 | | presence | live overlay |
 | --- | --- | --- |
 | Keyed by | adventure | **map** (you only see overlays on the map you're viewing) |
 | Identity | one entry per user | one entry per **(author, item)** — many coexist |
-| Payload | connection + current map | a discriminated union: scribble (pixel path) or ruler (grid nodes) |
-| Expiry | idle TTL after disconnect | per-kind fade after release; staleness timeout while active |
+| Payload | connection + current map | a discriminated union: scribble (un-snapped pixel path) or ruler (grid nodes + a live cursor node) |
+| Broadcast granularity | the whole user list, every time | the single changed item, plus an explicit removal when one expires |
+| Expiry | idle TTL (minutes) after the user's last socket closes | per-kind fade after release; short staleness timeout while active |
+| Cleanup on disconnect | explicit — closing a socket flips the user to disconnected and starts the TTL | none — items are only ever reaped by their expiry timer |
+
+The last row is the interesting one. Presence answers "is this person here?", so
+a disconnect *is* the event and has to be handled promptly. An overlay item is a
+mark someone made; a disconnect isn't special, because the timer that already
+guards against a dead client mid-drag reaps it anyway. Fewer code paths, one
+reaper.
 
 ## Why per-author streams (and not a shared document)
 
 Live overlays are modelled as **independent per-author streams**, not as one
 shared versioned document that everyone patches. This was a deliberate choice.
-The whole point of the feature is *several players drawing at once*; a single
-shared document with one version counter would serialise every writer through
-that counter, so concurrent edits would constantly collide and force full
-re-syncs. Per-author streams have no shared counter and no cross-writer
-contention: each item has exactly one author, nobody edits anyone else's, and
-"conflict resolution" simply doesn't arise.
+The considered alternative was a single JSON blob per map, synced by patches
+against a monotonic version counter. The whole point of the feature is *several
+players drawing at once*, and one counter serialises every writer through it, so
+concurrent edits would constantly lose the version race and force full refetches.
+It also implies conflict semantics that per-author items don't have. Per-author
+streams have no shared counter and no cross-writer contention: each item has
+exactly one author, nobody edits anyone else's, and "conflict resolution" simply
+doesn't arise.
 
 A consequence worth internalising: an overlay update **replaces** the item's
 geometry wholesale rather than appending to it. This keeps the backplane
 *payload-agnostic* — the server stores, forwards, and expires opaque items
-without understanding scribble points or ruler nodes. That agnosticism is what
-made adding rulers alongside scribbles nearly free, and what will make a third
-ephemeral kind cheap: define a payload type, a renderer, and an expiry timing.
+without understanding scribble points or ruler nodes. Appending would force the
+server to learn each payload's internals in order to merge them, which is exactly
+the coupling that made rulers nearly free to add alongside scribbles. (Sending a
+growing point array on every throttled tick of a long scribble is the price;
+delta-appending is available later as a scribble-only optimisation if profiling
+ever calls for it.) A third ephemeral kind stays cheap on the same terms: a
+payload type plus validator, an expiry timing, and a renderer.
+
+Presentation is deliberately absent from the payload. Per-author colour — the
+thing that makes several simultaneous scribbles legible — is derived client-side
+from `authorId` rather than sent, so the backplane never carries a styling
+decision it would then have to keep validating.
 
 ## Lifecycle: one timer, read two ways
 
@@ -114,6 +165,11 @@ once let go) and an expiry timer that **every update re-arms**:
   grab again to continue) with no special-case code: it's just repeated
   updates to one item.
 
+All three durations are named constants in the overlay registry, tunable per
+kind and overridable by tests. The mechanism doesn't care what the values are —
+only that "how long until this stops existing" is decided in one place, by the
+server.
+
 ## Who owns what: existence vs. pixels
 
 A useful split when reasoning about overlays:
@@ -124,7 +180,8 @@ A useful split when reasoning about overlays:
 - **Clients own the pixels.** The visual fade is animated locally from the
   item's `releasedAt` timestamp; clients don't wait for the server to tell them
   to dim. This keeps the animation smooth and means a dropped fire-and-forget
-  frame is self-healing.
+  frame is self-healing. (`releasedAt` is on the wire today for exactly this
+  reason; the renderers that consume it arrive with the UIs.)
 
 Implications that fall out of this:
 
@@ -144,9 +201,17 @@ Everything from the wire is treated as untrusted at the server boundary:
 - **Membership is enforced at subscribe time**, and an overlay send is only
   accepted from a socket that already holds a subscription for that map.
 - **Inputs are validated and bounded**: the payload is shape-checked and size-
-  capped, there's a per-author item ceiling, and a per-socket rate limit guards
+  capped, there's a per-author item ceiling, and a per-socket token bucket guards
   against floods. Malformed frames are dropped and logged, not fatal — a bad
-  transient frame should never close a session.
+  transient frame should never close a session, per the ephemeral-message
+  guidance in @docs/EPHEMERAL_WS.md.
+- **The validator rebuilds rather than inspects.** It returns a freshly
+  constructed object built only from fields it recognises, so unknown or
+  spoofed fields cannot ride into the registry and back out to peers. It
+  returns null instead of throwing; the caller drops the frame.
+- **The caps are shared, not server-private.** They live in the shared package
+  alongside the payload types, so a client-side guard and the server boundary
+  cannot drift apart on what "too long" means.
 
 ## Deliberate non-goals (today)
 
@@ -157,8 +222,12 @@ Everything from the wire is treated as untrusted at the server boundary:
   need a parallel fan-out (Postgres NOTIFY, Redis pub/sub, …). At single-
   instance scale this is a no-op and intentionally not built.
 - **No UI in the data layer.** Rendering, input capture, per-author colour, and
-  the off-edge "someone is scribbling over there" arrow live in the feature UIs,
-  not the backplane.
+  the off-edge "someone is scribbling over there" arrow belong to the feature
+  UIs, not the backplane — which is why the backplane could ship, and be tested,
+  before either UI existed.
+- **No delta protocol.** Updates replace; nothing appends. See above.
+- **No acks and no resend queue** for ephemeral frames — deliberately, not as an
+  omission. Correctness comes from the next snapshot, not from redelivery.
 
 ## Where the code lives
 
@@ -170,3 +239,9 @@ Everything from the wire is treated as untrusted at the server boundary:
 - Client surface: `ILiveData` in `was-web/packages/shared/src/services/liveData.ts`,
   implemented in `was-web/src/services/honoLiveData.ts` over
   `was-web/src/services/honoWebSocket.ts`.
+- Shared subscription machinery both paths use:
+  `was-web/server/src/ws/subscriptions.ts` and `was-web/server/src/ws/rooms.ts`.
+- Tests: `was-web/server/src/__tests__/ws-presence.test.ts` and
+  `ws-liveOverlay.test.ts` drive real sockets against the WebSocket harness;
+  `was-web/packages/shared/src/data/overlay.test.ts` covers the boundary
+  validator directly.


### PR DESCRIPTION
`docs/architecture/ephemeral-state.md` pointed at `docs/superpowers/specs/2026-06-07-ephemeral-overlay-data-layer-design.md`, which was deleted in 40fdda5 ("Remove temporary docs"). The spec turned out to be recoverable from git history (added in cd35d17, 339 lines), so rather than just dropping the dangling reference I recovered it and merged the material that existed only there — cross-checked against `liveOverlay.ts`, `presence.ts`, `handler.ts`, `overlay.ts`, `wsProtocol.ts`, `honoLiveData.ts` and `honoWebSocket.ts` before writing.

Docs only; no code changes.

## What the spec had that the doc didn't

- **A new "One socket, two backends" section.** The persistent/ephemeral split is a split of backends, not transports — both run through the same scope → snapshot → roomUpdate subscription machinery. Three consequences: authorization for ephemeral scopes is still the database-backed membership check; `liveOverlay` shares the map-keyed room manager with `mapChanges`, so every broadcast must filter room members by scope (being in the room isn't permission to receive); adding a scope is a local change.
- **Why replace-not-append**, as a generality argument rather than a simplicity one — appending would force the server to learn each payload's internals, which is the coupling that made rulers cheap to add. Plus its cost, and the scribble-only delta optimisation held in reserve.
- **The rejected alternative named**: a single per-map blob patched against a monotonic version counter, and why it thrashes under concurrent drawers.
- **Colour deliberately off the wire**, derived client-side from `authorId`.
- **Two more trust-boundary properties**: the validator reconstructs a clean object rather than inspecting in place (unknown fields can't ride through to peers), and the size caps live in the shared package so client and server can't drift.
- **Table rows** for broadcast granularity (presence sends the whole user list; overlay sends one item plus explicit removals) and disconnect cleanup (presence has an explicit hook; overlays are only ever reaped by their timer), with a note on why that asymmetry is right.

## One correction the code forced

Not in the spec, but the code is clear: **live overlays are a data layer only.** The spec was session 1 of 3, and sessions 2 and 3 never landed on `main` — nothing calls `watchLiveOverlays`, and the scribble UI is still on the `gh-331-scribble-mode` branch. The doc previously read as though scribbles and rulers were live features. There's now a status note up front, and the "clients own the pixels" claim is marked as the contract `releasedAt` exists to serve rather than as shipped behaviour.

Kept at architecture altitude throughout — boundaries, invariants and reasoning, not function-level detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)